### PR TITLE
Possible null pointer dereference in php_http_url_mod() fixed.

### DIFF
--- a/src/php_http_url.c
+++ b/src/php_http_url.c
@@ -263,6 +263,7 @@ php_http_url_t *php_http_url_mod(const php_http_url_t *old_url, const php_http_u
 
 	/* replace directory references if path is not a single slash */
 	if ((flags & PHP_HTTP_URL_SANITIZE_PATH)
+	&&	url(buf)->path
 	&&	url(buf)->path[0] && url(buf)->path[1]) {
 		char *ptr, *end = url(buf)->path + strlen(url(buf)->path) + 1;
 			


### PR DESCRIPTION
I somehow ended up initializing an `http\Url` object like this and crashed PHP:

```
$ cat url_deref.php
<?php
	$url = new http\Url(NULL, NULL, 0x2000);
?>
$ ./sapi/cli/php url_deref.php
[1]    23687 segmentation fault (core dumped)  ./sapi/cli/php url_deref.php
```

The provided patch should fix this issue.