### PR TITLE
avoid skipping test when current locale is C

### DIFF
--- a/tests/urlparser004.phpt
+++ b/tests/urlparser004.phpt
@@ -4,13 +4,14 @@ url parser multibyte/locale
 <?php
 include "skipif.inc";
 if (!defined("http\\Url::PARSE_MBLOC") or
-	!stristr(setlocale(LC_CTYPE, NULL), "utf")) {
+	!stristr(setlocale(LC_CTYPE, "C.UTF-8"), "utf")) {
 	die("skip need http\\Url::PARSE_MBLOC support and LC_CTYPE=*.UTF-8");
 }
 ?>
 --FILE--
 <?php
 echo "Test\n";
+setlocale(LC_CTYPE, "C.UTF-8");
 
 $urls = array(
 	"s\xc3\xa7heme:",

--- a/tests/urlparser006.phpt
+++ b/tests/urlparser006.phpt
@@ -5,13 +5,14 @@ url parser multibyte/locale/idna
 include "skipif.inc";
 if (!defined("http\\Url::PARSE_MBLOC") or
 	!defined("http\\Url::PARSE_TOIDN_2003") or
-	!stristr(setlocale(LC_CTYPE, NULL), ".utf")) {
+	!stristr(setlocale(LC_CTYPE, "C.UTF-8"), ".utf")) {
 	die("skip need http\\Url::PARSE_MBLOC|http\\Url::PARSE_TOIDN_2003 support and LC_CTYPE=*.UTF-8");
 }
 ?>
 --FILE--
 <?php
 echo "Test\n";
+setlocale(LC_CTYPE, "C.UTF-8");
 
 $urls = array(
 	"s\xc3\xa7heme:",

--- a/tests/urlparser010.phpt
+++ b/tests/urlparser010.phpt
@@ -4,7 +4,7 @@ url parser multibyte/locale/topct
 <?php
 include "skipif.inc";
 if (!defined("http\\Url::PARSE_MBLOC") or
-	!stristr(setlocale(LC_CTYPE, NULL), ".utf")) {
+	!stristr(setlocale(LC_CTYPE, "C.UTF-8"), ".utf")) {
 	die("skip need http\\Url::PARSE_MBLOC support and LC_CTYPE=*.UTF-8");
 }
 
@@ -12,6 +12,7 @@ if (!defined("http\\Url::PARSE_MBLOC") or
 --FILE--
 <?php
 echo "Test\n";
+setlocale(LC_CTYPE, "C.UTF-8");
 
 $urls = array(
 	"http://mike:paßwort@𐌀𐌁𐌂.it/for/€/?by=¢#ø"

--- a/tests/urlparser012.phpt
+++ b/tests/urlparser012.phpt
@@ -5,7 +5,7 @@ url parser multibyte/locale/topct
 include "skipif.inc";
 if (!defined("http\\Url::PARSE_MBLOC") or
 	!defined("http\\Url::PARSE_TOIDN") or
-	!stristr(setlocale(LC_CTYPE, NULL), ".utf")) {
+	!stristr(setlocale(LC_CTYPE, "C.UTF-8"), ".utf")) {
 	die("skip need http\\Url::PARSE_MBLOC|http\Url::PARSE_TOIDN support and LC_CTYPE=*.UTF-8");
 }
 
@@ -13,6 +13,7 @@ if (!defined("http\\Url::PARSE_MBLOC") or
 --FILE--
 <?php
 echo "Test\n";
+setlocale(LC_CTYPE, "C.UTF-8");
 
 $urls = array(
 	"http://mike:paßwort@𐌀𐌁𐌂.it/for/€/?by=¢#ø"


### PR DESCRIPTION
@m6w6 can you please check this (well... travis will do)

To avoid
```
SKIP url parser multibyte/locale [tests/urlparser004.phpt] reason: need http\Url::PARSE_MBLOC support and LC_CTYPE=*.UTF-8
SKIP url parser multibyte/locale/idna [tests/urlparser006.phpt] reason: need http\Url::PARSE_MBLOC|http\Url::PARSE_TOIDN_2003 support and LC_CTYPE=*.UTF-8
SKIP url parser multibyte/locale/topct [tests/urlparser010.phpt] reason: need http\Url::PARSE_MBLOC support and LC_CTYPE=*.UTF-8
SKIP url parser multibyte/locale/topct [tests/urlparser012.phpt] reason: need http\Url::PARSE_MBLOC|http\Url::PARSE_TOIDN support and LC_CTYPE=*.UTF-8
```