### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,4 @@
 dnl phpize stub of config9.m4 for pecl/http
-dnl $Id: config.m4 214417 2006-06-07 21:05:34Z mike $
 dnl vim: noet ts=1 sw=1
 
 sinclude(config9.m4)

--- a/config.w32
+++ b/config.w32
@@ -1,5 +1,4 @@
 // config.w32 for pecl/http
-// $Id$
 
 ARG_ENABLE("http", "whether to enable extended HTTP support", "no");
 


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character
hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore.

Thanks for considering merging this or checking it out.