### PR TITLE
Replace obsolete AC_TRY_FOO with AC_FOO_IFELSE

### DIFF
--- a/autoconf/pecl/libcurl.m4
+++ b/autoconf/pecl/libcurl.m4
@@ -46,7 +46,7 @@ dnl
 AC_DEFUN([PECL_HAVE_LIBCURL_SSLLIB], [
 	if test -z "$PECL_VAR([LIBCURL_SSLLIB])"; then
 		AC_CACHE_CHECK([for $1 providing SSL in libcurl], PECL_CACHE_VAR([HAVE_LIBCURL_$1]), [
-			AC_TRY_RUN([
+			AC_RUN_IFELSE([AC_LANG_SOURCE([[
 				#include <strings.h>
 				#include <curl/curl.h>
 				int main(int argc, char *argv[]) {
@@ -58,11 +58,11 @@ AC_DEFUN([PECL_HAVE_LIBCURL_SSLLIB], [
 					}
 					return 1;
 				}
-			], [
+			]])],[
 				PECL_CACHE_VAR([HAVE_LIBCURL_$1])=yes
-			], [
+			],[
 				PECL_CACHE_VAR([HAVE_LIBCURL_$1])=no
-			])
+			],[])
 		])
 		PECL_VAR([HAVE_LIBCURL_$1])=$PECL_CACHE_VAR([HAVE_LIBCURL_$1])
 		if $PECL_VAR([HAVE_LIBCURL_$1]); then
@@ -106,9 +106,9 @@ AC_DEFUN([PECL_HAVE_LIBCURL_SSL], [dnl
 			AC_CACHE_CHECK([whether NSS PEM is available], [PECL_CACHE_VAR([HAVE_LIBCURL_NSSPEM])], [
 				PECL_SAVE_ENV([LIBS], [NSSPEM])
 				LIBS="$LIBS -lnsspem"
-				AC_TRY_LINK([], [(void)0;], [
+				AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[(void)0;]])],[
 					PECL_CACHE_VAR([HAVE_LIBCURL_NSSPEM])=yes
-				], [
+				],[
 					PECL_CACHE_VAR([HAVE_LIBCURL_NSSPEM])=no
 				])
 				PECL_RESTORE_ENV([LIBS], [NSSPEM])
@@ -129,25 +129,21 @@ AC_DEFUN([PECL_HAVE_LIBCURL_SSL], [dnl
 		PECL_HAVE_CONST([curl/curl.h], [CURLOPT_TLSAUTH_TYPE], int, [
 			AC_CACHE_CHECK([whether CURLOPT_TLSAUTH_TYPE expects CURL_TLSAUTH_SRP], PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP]), [
 				PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])=
-				AC_TRY_RUN([
+				AC_RUN_IFELSE([AC_LANG_SOURCE([[
 					#include <curl/curl.h>
 					int main(int argc, char *argv[]) {
 						CURL *ch = curl_easy_init();
 						return curl_easy_setopt(ch, CURLOPT_TLSAUTH_TYPE, CURL_TLSAUTH_SRP);
 					}
-				], [
-					PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])=yes
-				], [
-					AC_TRY_RUN([
+				]])],[PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])=yes],[
+					AC_RUN_IFELSE([AC_LANG_SOURCE([[
 						#include <curl/curl.h>
 						int main(int argc, char *argv[]) {
 							CURL *ch = curl_easy_init();
 							return curl_easy_setopt(ch, CURLOPT_TLSAUTH_TYPE, "SRP");
 						}
-					], [
-						PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])=no
-					])
-				])
+					]])],[PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])=no],[],[])
+				],[])
 			])
 			if test -n "$PECL_CACHE_VAR([LIBCURL_TLSAUTH_SRP])"; then
 				PECL_DEFINE([HAVE_LIBCURL_TLSAUTH_TYPE])
@@ -167,7 +163,7 @@ dnl PECL_HAVE_LIBCURL_ARES
 dnl
 AC_DEFUN([PECL_HAVE_LIBCURL_ARES], [
 	AC_CACHE_CHECK([for c-ares providing AsynchDNS in libcurl], PECL_CACHE_VAR([HAVE_LIBCURL_ARES]), [
-		AC_TRY_RUN([
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[
 			#include <curl/curl.h>
 			int main(int argc, char *argv[]) {
 				curl_version_info_data *data = curl_version_info(CURLVERSION_NOW);
@@ -176,11 +172,11 @@ AC_DEFUN([PECL_HAVE_LIBCURL_ARES], [
 				}
 				return 1;
 			}
-		], [
+		]])],[
 			PECL_CACHE_VAR([HAVE_LIBCURL_ARES])=yes
-		], [
+		],[
 			PECL_CACHE_VAR([HAVE_LIBCURL_ARES])=no
-		])
+		],[])
 	])
 	PECL_VAR([HAVE_LIBCURL_ARES])=$PECL_CACHE_VAR([HAVE_LIBCURL_ARES])
 	if $PECL_VAR([HAVE_LIBCURL_ARES]); then

--- a/autoconf/pecl/pecl.m4
+++ b/autoconf/pecl/pecl.m4
@@ -180,14 +180,14 @@ dnl
 AC_DEFUN([PECL_HAVE_CONST], [dnl
 	AC_REQUIRE([PECL_PROG_EGREP])dnl
 	AC_CACHE_CHECK([for $2 in $1], PECL_CACHE_VAR([HAVE_$1_$2]), [
-		AC_TRY_COMPILE([
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 			#include "$1"
-		], [
-			]ifelse([$3],,int,[$3])[ _c = $2;
+		]], [[
+			ifelse($3,,int,$3) _c = $2;
 			(void) _c;
-		], [
+		]])],[
 			PECL_CACHE_VAR([HAVE_$1_$2])=yes
-		], [
+		],[
 			PECL_CACHE_VAR([HAVE_$1_$2])=no
 		])
 	])

--- a/config9.m4
+++ b/config9.m4
@@ -94,13 +94,13 @@ if test "$PHP_HTTP" != "no"; then
 					CFLAGS="$CFLAGS -Wno-error=deprecated-declarations"
 				fi
 			fi
-			AC_TRY_LINK([
+			AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 				#include <unicode/uidna.h>
-			], [
+			]], [[
 				uidna_IDNToASCII(0, 0, 0, 0, 0, 0, 0);
-			], [
+			]])],[
 				PECL_CACHE_VAR([HAVE_UIDNA_IDNToASCII])=yes
-			], [
+			],[
 				PECL_CACHE_VAR([HAVE_UIDNA_IDNToASCII])=no
 			])
 		])
@@ -110,13 +110,13 @@ if test "$PHP_HTTP" != "no"; then
 		fi
 
 		AC_CACHE_CHECK([for uidna_nameToASCII_UTF8], PECL_CACHE_VAR([HAVE_UIDNA_NAMETOASCII_UTF8]), [
-			AC_TRY_LINK([
+			AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 				#include <unicode/uidna.h>
-			], [
+			]], [[
 				uidna_nameToASCII_UTF8(0, 0, 0, 0, 0, 0, 0);
-			], [
+			]])],[
 				PECL_CACHE_VAR([HAVE_UIDNA_NAMETOASCII_UTF8])=yes
-			], [
+			],[
 				PECL_CACHE_VAR([HAVE_UIDNA_NAMETOASCII_UTF8])=no
 			])
 		])


### PR DESCRIPTION
Hello,

Autoconf made several macros obsolete including the `AC_TRY_COMPILE`, `AC_TRY_LINK`, and `AC_TRY_RUN` around 2000 since Autoconf 2.50:
http://git.savannah.gnu.org/cgit/autoconf.git/tree/ChangeLog.2

These macros should be replaced with the current `AC_FOO_IFELSE` macros instead.

It is fairly safe to upgrade and take the recommendation advice of autoconf upgrade manual since the upgrade should be compatible at least with PHP versions 5.4 and up, on some systems even with PHP 5.3. PHP versions from 5.4 to 7.1 require Autoconf 2.59+ and PHP 7.2+ require Autoconf 2.64+.

This patch was created with the help of the autoupdate script.

Reference docs:
- https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html
- https://www.gnu.org/software/autoconf/manual/autoconf-2.59/autoconf.pdf

Thanks for considering adding this or checking it out.