### PR TITLE
Mitigate strange segfault in tests/client012.phpt

### DIFF
--- a/src/php_http_client_curl.c
+++ b/src/php_http_client_curl.c
@@ -516,11 +516,7 @@ static ZEND_RESULT_CODE php_http_curle_get_info(CURL *ch, HashTable *info)
 		zval ti_array, subarray;
 		struct curl_tlssessioninfo *ti;
 
-#if PHP_HTTP_CURL_VERSION(7,48,0)
-		if (CURLE_OK == curl_easy_getinfo(ch, CURLINFO_TLS_SSL_PTR, &ti)) {
-#else
 		if (CURLE_OK == curl_easy_getinfo(ch, CURLINFO_TLS_SESSION, &ti)) {
-#endif
 			char *backend;
 
 			ZVAL_NULL(&subarray);
@@ -534,12 +530,7 @@ static ZEND_RESULT_CODE php_http_curle_get_info(CURL *ch, HashTable *info)
 				backend = "openssl";
 #if PHP_HTTP_HAVE_LIBCURL_OPENSSL
 				{
-#if PHP_HTTP_CURL_VERSION(7,48,0)
-					SSL *ssl = ti->internals;
-					SSL_CTX *ctx = ssl ? SSL_get_SSL_CTX(ssl) : NULL;
-#else
 					SSL_CTX *ctx = ti->internals;
-#endif
 
 					array_init(&subarray);
 					if (ctx) {


### PR DESCRIPTION
Building on debian stretch against [libcurl4-openssl-dev 7.52.1-5+deb9u6](https://packages.debian.org/stretch/libcurl4-openssl-dev) (current) I get a segfault in [this test](https://github.com/m6w6/ext-http/blob/293d4e19c4b8c8da8cd4295c5b55a66a232e763a/tests/client012.phpt). I have been unable to reproduce it in any other environment, so I assume it is a problem with one of the dependencies rather than this extension (probably openssl, as you will see in a minute) - however it can be mitigated in the extension.

Digging into it, the problem is that [`SSL_get_SSL_CTX()`](https://github.com/m6w6/ext-http/blob/293d4e19c4b8c8da8cd4295c5b55a66a232e763a/src/php_http_client_curl.c#L539) is returning garbage - it always seems to return `0x19000` - which results in a segfault when the pointer is dereferenced further down. However, if I switch to the pre-7.48 branch (i.e. use `CURLINFO_TLS_SESSION` instead of `CURLINFO_TLS_SSL_PTR`) then I get a valid pointer, the data is retrieved correctly, the test passes and there is no segfault. I cannot see any obvious problem with the code in the `CURLINFO_TLS_SSL_PTR` branch, I can only assume it is an upstream bug - although I cannot find any similar reports against libcurl or openssl either.

Since no following code actually *requires* the `SSL*` handle, I propose switching to always use `CURLINFO_TLS_SESSION` and accessing the `SSL_CTX*` handle directly. This would be a simplification of the code, and avoids this issue. If a future feature requires the `SSL*` handle... well, we can cross that bridge when we come to it :stuck_out_tongue:

For reference, here's the valgrind details of the issue:

```
==15969== Invalid read of size 8
==15969==    at 0x5D784D0: SSL_CTX_ctrl (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
==15969==    by 0xA03A397: php_http_curle_get_info (php_http_client_curl.c:546)
==15969==    by 0xA03A397: php_http_client_curl_getopt (php_http_client_curl.c:2433)
==15969==    by 0xA0360EE: zim_HttpClient_getTransferInfo (php_http_client.c:1148)
==15969==    by 0x4BD79E: execute_ex (in /usr/bin/php7.2-zts)
==15969==    by 0x3EC80C: zend_call_function (in /usr/bin/php7.2-zts)
==15969==    by 0xA062866: php_http_object_method_call (php_http_object.c:112)
==15969==    by 0xA033503: notify (php_http_client.c:980)
==15969==    by 0x2E3A08: spl_iterator_apply (in /usr/bin/php7.2-zts)
==15969==    by 0xA033402: zim_HttpClient_notify (php_http_client.c:1020)
==15969==    by 0x3EC607: zend_call_function (in /usr/bin/php7.2-zts)
==15969==    by 0xA062866: php_http_object_method_call (php_http_object.c:112)
==15969==    by 0xA03367A: handle_progress (php_http_client.c:529)
==15969==  Address 0x19020 is not stack'd, malloc'd or (recently) free'd
```