### PR TITLE
Windows & PHP 7.4 fixes

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -110,10 +110,13 @@ if (PHP_HTTP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("curl/curl.h", "CFLAGS_HTTP") &&
 			CHECK_HEADER_ADD_INCLUDE("openssl/crypto.h", "CFLAGS_HTTP") &&
 			CHECK_LIB(CURL_LIB, "http", PHP_HTTP) &&
+			CHECK_LIB("wldap32.lib", "http", PHP_HTTP) &&
+			CHECK_LIB("libssh2.lib;libssh2_a.lib", "http", PHP_HTTP) &&
+			CHECK_LIB("nghttp2.lib;nghttp2_a.lib", "http", PHP_HTTP) &&
+			CHECK_LIB("normaliz.lib", "http", PHP_HTTP) &&
 			CHECK_LIB("libssl.lib;ssleay32.lib", "http", PHP_HTTP) &&
 			CHECK_LIB("libcrypto.lib;libeay32.lib", "http", PHP_HTTP) &&
 			CHECK_LIB("zlib.lib;zlib_a.lib", "http", PHP_HTTP) &&
-			CHECK_LIB("libcurl_a.lib", "http", PHP_HTTP) &&
 			ADD_EXTENSION_DEP("http", "propro", true) &&
 			ADD_EXTENSION_DEP("http", "raphf", true) &&
 			CHECK_LIB("winmm.lib", "http", PHP_HTTP)) {

--- a/config.w32
+++ b/config.w32
@@ -110,8 +110,8 @@ if (PHP_HTTP != "no") {
 	if (CHECK_HEADER_ADD_INCLUDE("curl/curl.h", "CFLAGS_HTTP") &&
 			CHECK_HEADER_ADD_INCLUDE("openssl/crypto.h", "CFLAGS_HTTP") &&
 			CHECK_LIB(CURL_LIB, "http", PHP_HTTP) &&
-			CHECK_LIB("ssleay32.lib", "http", PHP_HTTP) &&
-			CHECK_LIB("libeay32.lib", "http", PHP_HTTP) &&
+			CHECK_LIB("libssl.lib;ssleay32.lib", "http", PHP_HTTP) &&
+			CHECK_LIB("libcrypto.lib;libeay32.lib", "http", PHP_HTTP) &&
 			CHECK_LIB("zlib.lib;zlib_a.lib", "http", PHP_HTTP) &&
 			CHECK_LIB("libcurl_a.lib", "http", PHP_HTTP) &&
 			ADD_EXTENSION_DEP("http", "propro", true) &&

--- a/src/php_http_client_curl.c
+++ b/src/php_http_client_curl.c
@@ -46,7 +46,7 @@ typedef struct php_http_client_curl_handler {
 		php_http_buffer_t ranges;
 
 		struct {
-			uint count;
+			uint32_t count;
 			double delay;
 		} retry;
 

--- a/src/php_http_curl.c
+++ b/src/php_http_curl.c
@@ -43,9 +43,9 @@ static void php_http_openssl_thread_lock(int mode, int n, const char * file, int
 	}
 }
 
-static ulong php_http_openssl_thread_id(void)
+static unsigned long php_http_openssl_thread_id(void)
 {
-	return (ulong) tsrm_thread_id();
+	return (unsigned long) tsrm_thread_id();
 }
 #endif
 #if PHP_HTTP_NEED_GNUTLS_TSL

--- a/src/php_http_encoding.c
+++ b/src/php_http_encoding.c
@@ -36,7 +36,7 @@ const char *php_http_encoding_dechunk(const char *encoded, size_t encoded_len, c
 	*decoded = ecalloc(1, encoded_len + 1);
 
 	while ((encoded + encoded_len - e_ptr) > 0) {
-		ulong chunk_len = 0, rest;
+		unsigned long chunk_len = 0, rest;
 
 		chunk_len = strtoul(e_ptr, &n_ptr, 16);
 
@@ -237,7 +237,7 @@ void php_http_encoding_stream_free(php_http_encoding_stream_t **s)
 
 struct dechunk_ctx {
 	php_http_buffer_t buffer;
-	ulong hexlen;
+	unsigned long hexlen;
 	unsigned zeroed:1;
 };
 

--- a/src/php_http_etag.c
+++ b/src/php_http_etag.c
@@ -26,8 +26,8 @@ php_http_etag_t *php_http_etag_init(const char *mode)
 	php_http_etag_t *e;
 
 	if (mode && (!strcasecmp(mode, "crc32b"))) {
-		ctx = emalloc(sizeof(uint));
-		*((uint *) ctx) = ~0;
+		ctx = emalloc(sizeof(uint32_t));
+		*((uint32_t *) ctx) = ~0;
 	} else if (mode && !strcasecmp(mode, "sha1")) {
 		PHP_SHA1Init(ctx = emalloc(sizeof(PHP_SHA1_CTX)));
 	} else if (mode && !strcasecmp(mode, "md5")) {
@@ -57,7 +57,7 @@ char *php_http_etag_finish(php_http_etag_t *e)
 	char *etag = NULL;
 
 	if (!strcasecmp(e->mode, "crc32b")) {
-		uint e_ctx;
+		uint32_t e_ctx;
 		memcpy(&e_ctx, e->ctx, 4);
 		e_ctx = ntohl(~e_ctx);
 		etag = php_http_etag_digest((unsigned char *) &e_ctx, 4);
@@ -88,11 +88,11 @@ char *php_http_etag_finish(php_http_etag_t *e)
 size_t php_http_etag_update(php_http_etag_t *e, const char *data_ptr, size_t data_len)
 {
 	if (!strcasecmp(e->mode, "crc32b")) {
-		uint i, c = *((uint *) e->ctx);
+		uint32_t i, c = *((uint32_t *) e->ctx);
 		for (i = 0; i < data_len; ++i) {
 			CRC32(c, data_ptr[i]);
 		}
-		*((uint *) e->ctx) = c;
+		*((uint32_t *) e->ctx) = c;
 	} else if ((!strcasecmp(e->mode, "sha1"))) {
 		PHP_SHA1Update(e->ctx, (const unsigned char *) data_ptr, data_len);
 	} else if ((!strcasecmp(e->mode, "md5"))) {

--- a/src/php_http_filter.c
+++ b/src/php_http_filter.c
@@ -72,7 +72,7 @@ PHP_MINIT_FUNCTION(http_filter)
 
 typedef struct _http_chunked_decode_filter_buffer_t {
 	php_http_buffer_t	buffer;
-	ulong	hexlen;
+	unsigned long	hexlen;
 } PHP_HTTP_FILTER_BUFFER(chunked_decode);
 
 typedef php_http_encoding_stream_t PHP_HTTP_FILTER_BUFFER(stream);

--- a/src/php_http_message_body.c
+++ b/src/php_http_message_body.c
@@ -393,7 +393,7 @@ static ZEND_RESULT_CODE add_recursive_files(php_http_message_body_t *body, const
 			{
 				if (Z_TYPE_P(val) == IS_ARRAY || Z_TYPE_P(val) == IS_OBJECT) {
 					char *str = key.key ? format_key(&key, name) : NULL;
-					const char *prefix = str ?: name;
+					const char *prefix = str ? str : name;
 
 					if (SUCCESS != add_recursive_files(body, prefix, HASH_OF(val))) {
 						efree(str);

--- a/src/php_http_message_parser.c
+++ b/src/php_http_message_parser.c
@@ -323,7 +323,7 @@ php_http_message_parser_state_t php_http_message_parser_parse(php_http_message_p
 					}
 
 					if (content_range) {
-						ulong total = 0, start = 0, end = 0;
+						unsigned long total = 0, start = 0, end = 0;
 
 						if (!strncasecmp(content_range->val, "bytes", lenof("bytes"))
 						&& (	content_range->val[lenof("bytes")] == ':'

--- a/src/php_http_options.c
+++ b/src/php_http_options.c
@@ -74,7 +74,7 @@ void php_http_options_free(php_http_options_t **registry)
 	}
 }
 
-php_http_option_t *php_http_option_register(php_http_options_t *registry, const char *name_str, size_t name_len, ulong option, zend_uchar type)
+php_http_option_t *php_http_option_register(php_http_options_t *registry, const char *name_str, size_t name_len, unsigned long option, zend_uchar type)
 {
 	php_http_option_t opt;
 

--- a/src/php_http_options.h
+++ b/src/php_http_options.h
@@ -32,7 +32,7 @@ struct php_http_option {
 	php_http_options_t suboptions;
 
 	zend_string *name;
-	ulong option;
+	unsigned long option;
 	zend_uchar type;
 	unsigned flags;
 	zval defval;
@@ -46,7 +46,7 @@ PHP_HTTP_API ZEND_RESULT_CODE php_http_options_apply(php_http_options_t *registr
 PHP_HTTP_API void php_http_options_dtor(php_http_options_t *registry);
 PHP_HTTP_API void php_http_options_free(php_http_options_t **registry);
 
-PHP_HTTP_API php_http_option_t *php_http_option_register(php_http_options_t *registry, const char *name_str, size_t name_len, ulong option, zend_uchar type);
+PHP_HTTP_API php_http_option_t *php_http_option_register(php_http_options_t *registry, const char *name_str, size_t name_len, unsigned long option, zend_uchar type);
 PHP_HTTP_API zval *php_http_option_get(php_http_option_t *opt, HashTable *options, void *userdata);
 
 #endif /* PHP_HTTP_OPTIONS_H */

--- a/src/php_http_querystring.c
+++ b/src/php_http_querystring.c
@@ -63,7 +63,7 @@ static inline void php_http_querystring_str(zval *instance, zval *return_value)
 	}
 }
 
-static inline void php_http_querystring_get(zval *instance, int type, char *name, uint name_len, zval *defval, zend_bool del, zval *return_value)
+static inline void php_http_querystring_get(zval *instance, int type, char *name, uint32_t name_len, zval *defval, zend_bool del, zval *return_value)
 {
 	zval *arrval, qarray_tmp, *qarray = zend_read_property(php_http_querystring_class_entry, instance, ZEND_STRL("queryArray"), 0, &qarray_tmp);
 


### PR DESCRIPTION
This PR solves a couple of issues.

PHP 7.4: change ulong to unsigned long and uint to uit32_t

Windows builds:
- Fix operator error which doesnot exist in Visual Studio
- Check for OpenSSL 1.1.1 libs first, then for OpenSSL 1.0.2 libs
- Add Curl dependent libs