### PR TITLE
switch to new serialization mechanism

### DIFF
--- a/tests/envresponse016.phpt
+++ b/tests/envresponse016.phpt
@@ -10,7 +10,7 @@ include "skipif.inc";
 echo "Test\n";
 
 class closer extends php_user_filter {
-	function filter ($in, $out, &$consumed, $closing) {
+	function filter ($in, $out, &$consumed, $closing): int {
 		while ($bucket = stream_bucket_make_writeable($in)) {
 			stream_bucket_append($out, $bucket);
 		}


### PR DESCRIPTION
See
https://wiki.php.net/rfc/phase_out_serializable
https://wiki.php.net/rfc/custom_object_serialization

So this is supported since 7.4, and mandatory in 8.1

Drop Serializable interface usage, and implement new magic methods

NOTICE: this mean incompatibility with previous version and serialized data.

BTW.... serialized data should only be used for local temporary data... should be...

Test suite passes with both 8.0.7 and 8.1.0alpha1


P.S. old implementation is kept where used for toString.