### PR TITLE
fix proto for 8.1.0beta2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,13 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 http.la
 install-sh
 lcov_data
 libtool
 ltmain.sh
+ltmain.sh.backup
 missing
 mkinstalldirs
 modules/
@@ -32,6 +34,7 @@ pecl_http-*.tgz
 *.lo
 *.o
 run-tests.php
+run-tests.sh
 tests/*.diff
 tests/*.exp
 tests/*.log

--- a/src/php_http_client.c
+++ b/src/php_http_client.c
@@ -984,7 +984,11 @@ static int notify(zend_object_iterator *iter, void *puser)
 	return ZEND_HASH_APPLY_STOP;
 }
 
+#if PHP_VERSION_ID < 80100
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_notify, 0, 0, 0)
+#else
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_HttpClient_notify, 0, 0, IS_VOID, 0)
+#endif
 	ZEND_ARG_OBJ_INFO(0, request, http\\Client\\Request, 1)
 	ZEND_ARG_INFO(0, progress)
 ZEND_END_ARG_INFO();
@@ -1032,7 +1036,11 @@ static PHP_METHOD(HttpClient, notify)
 	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
+#if PHP_VERSION_ID < 80100
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_attach, 0, 0, 1)
+#else
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_HttpClient_attach, 0, 1, IS_VOID, 0)
+#endif
 	ZEND_ARG_OBJ_INFO(0, observer, SplObserver, 0)
 ZEND_END_ARG_INFO();
 static PHP_METHOD(HttpClient, attach)
@@ -1061,7 +1069,11 @@ static PHP_METHOD(HttpClient, attach)
 	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
+#if PHP_VERSION_ID < 80100
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_detach, 0, 0, 1)
+#else
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(ai_HttpClient_detach, 0, 1, IS_VOID, 0)
+#endif
 	ZEND_ARG_OBJ_INFO(0, observer, SplObserver, 0)
 ZEND_END_ARG_INFO();
 static PHP_METHOD(HttpClient, detach)

--- a/tests/client002.phpt
+++ b/tests/client002.phpt
@@ -14,6 +14,7 @@ echo "Test\n";
 
 class Observer implements SplObserver
 {
+	#[ReturnTypeWillChange]
 	function update(SplSubject $client, http\Client\Request $request = null, StdClass $progress = null) {
 		echo "P";
 		if ($progress->info !== "prepare" && $client->getProgressInfo($request) != $progress) {

--- a/tests/client012.phpt
+++ b/tests/client012.phpt
@@ -26,6 +26,7 @@ var_dump(
 
 $client->attach($observer = new class implements SplObserver { 
 	public $data = [];
+	#[ReturnTypeWillChange]
 	function update(SplSubject $client, $req = null, $progress = null) {
 		$ti = $client->getTransferInfo($req);
 		if (isset($ti->tls_session["internals"])) {

--- a/tests/client013.phpt
+++ b/tests/client013.phpt
@@ -16,11 +16,13 @@ class Client extends http\Client {
 	public $pi;
 }
 class ProgressObserver1 implements SplObserver {
+	#[ReturnTypeWillChange]
 	function update(SplSubject $c, $r = null) {
 		if ($c->getProgressInfo($r)) $c->pi .= "-";
 	}
 }
 class ProgressObserver2 implements SplObserver {
+	#[ReturnTypeWillChange]
 	function update(SplSubject $c, $r = null) {
 		if ($c->getProgressInfo($r)) $c->pi .= ".";
 	}
@@ -30,6 +32,7 @@ class CallbackObserver implements SplObserver {
 	function __construct($callback) {
 		$this->callback = $callback;
 	}
+	#[ReturnTypeWillChange]
 	function update(SplSubject $c, $r = null) {
 		call_user_func($this->callback, $c, $r);
 	}

--- a/tests/client030.phpt
+++ b/tests/client030.phpt
@@ -12,6 +12,7 @@ echo "Test\n";
 include "helper/server.inc";
 
 class test implements SplObserver {
+	#[ReturnTypeWillChange]
 	function update(SplSubject $client) {
 		$client->once();
 	}

--- a/tests/envresponse016.phpt
+++ b/tests/envresponse016.phpt
@@ -10,6 +10,7 @@ include "skipif.inc";
 echo "Test\n";
 
 class closer extends php_user_filter {
+	#[ReturnTypeWillChange]
 	function filter ($in, $out, &$consumed, $closing) {
 		while ($bucket = stream_bucket_make_writeable($in)) {
 			stream_bucket_append($out, $bucket);


### PR DESCRIPTION
Without
```

$ php -n -d extension=raphf -d extension=modules/http.so  -v

Deprecated: Return type of http\Client::attach(SplObserver $observer) should either be compatible with SplSubject::attach(SplObserver $observer): void, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of http\Client::detach(SplObserver $observer) should either be compatible with SplSubject::detach(SplObserver $observer): void, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

Deprecated: Return type of http\Client::notify(?http\Client\Request $request = <default>, $progress = <default>) should either be compatible with SplSubject::notify(): void, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in Unknown on line 0

```

With
```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :  123
---------------------------------------------------------------------

Number of tests :  202               199
Tests skipped   :    3 (  1.5%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :  199 ( 98.5%) (100.0%)
---------------------------------------------------------------------
Time taken      :   10 seconds
=====================================================================

```
