### PR TITLE
Fix some build warnings

### DIFF
--- a/src/php_http_client_curl.c
+++ b/src/php_http_client_curl.c
@@ -313,14 +313,14 @@ static int php_http_curle_raw_callback(CURL *ch, curl_infotype type, char *data,
 	return 0;
 }
 
-static int php_http_curle_header_callback(char *data, size_t n, size_t l, void *arg)
+static size_t php_http_curle_header_callback(char *data, size_t n, size_t l, void *arg)
 {
 	php_http_client_curl_handler_t *h = arg;
 
 	return php_http_buffer_append(&h->response.headers, data, n * l);
 }
 
-static int php_http_curle_body_callback(char *data, size_t n, size_t l, void *arg)
+static size_t php_http_curle_body_callback(char *data, size_t n, size_t l, void *arg)
 {
 	php_http_client_curl_handler_t *h = arg;
 

--- a/src/php_http_message.c
+++ b/src/php_http_message.c
@@ -1780,6 +1780,7 @@ static PHP_METHOD(HttpMessage, __serialize)
 
 	ZEND_HASH_FOREACH_KEY_PTR(&obj->zo.ce->properties_info, num_index, str_index, pi)
 	{
+		(void)num_index;
 		zval *val;
 		if (str_index && (val = zend_hash_find_ind(props, pi->name))) {
 			Z_TRY_ADDREF_P(val);


### PR DESCRIPTION
At least first commit seems a real problem 
I dont know is change from int / size_t is related to some libcurl version, but at least already size_t in 7.29 on RHEL 7

