### PR TITLE
Fix incompatible pointer types (32-bit)

### DIFF
--- a/src/php_http_url.c
+++ b/src/php_http_url.c
@@ -73,7 +73,7 @@ static inline char *localhostname(void)
 static php_http_url_t *php_http_url_from_env(void)
 {
 	zval *https, *zhost, *zport;
-	long port;
+	zend_long port;
 	php_http_buffer_t buf;
 
 	php_http_buffer_init_ex(&buf, MAX(PHP_HTTP_BUFFER_DEFAULT_SIZE, sizeof(php_http_url_t)<<2), PHP_HTTP_BUFFER_INIT_PREALLOC);


### PR DESCRIPTION
With GCC 14 (Fedora 40) [-Wincompatible-pointer-types] becomes a error (and is indeed one)

See https://kojipkgs.fedoraproject.org//work/tasks/9963/112369963/build.log

```
/builddir/build/BUILD/php-pecl-http-4.2.4/pecl_http-4.2.4/src/php_http_url.c: In function 'php_http_url_from_env':
/builddir/build/BUILD/php-pecl-http-4.2.4/pecl_http-4.2.4/src/php_http_url.c:110:89: error: passing argument 3 of 'is_numeric_string' from incompatible pointer type [-Wincompatible-pointer-types]
  110 |         if (zport && IS_LONG == is_numeric_string(Z_STRVAL_P(zport), Z_STRLEN_P(zport), &port, NULL, 0)) {
      |                                                                                         ^~~~~
      |                                                                                         |
      |                                                                                         long int *
In file included from /usr/include/php/Zend/zend.h:417,
                 from /usr/include/php/main/php.h:31,
                 from /builddir/build/BUILD/php-pecl-http-4.2.4/pecl_http-4.2.4/src/php_http_api.h:31,
                 from /builddir/build/BUILD/php-pecl-http-4.2.4/pecl_http-4.2.4/src/php_http_url.c:13:
/usr/include/php/Zend/zend_operators.h:157:96: note: expected 'zend_long *' {aka 'int *'} but argument is of type 'long int *'
  157 | static zend_always_inline uint8_t is_numeric_string(const char *str, size_t length, zend_long *lval, double *dval, bool allow_errors) {
  
```    |                                                                                     ~~~~~~~~~~~^~~~
