### PR TITLE
fix incompatible pointer type

### DIFF
--- a/src/php_http_client_curl.h
+++ b/src/php_http_client_curl.h
@@ -25,7 +25,7 @@ typedef struct php_http_client_curl_handle {
 } php_http_client_curl_handle_t;
 
 typedef struct php_http_client_curl_ops {
-	void *(*init)();
+	void *(*init)(php_http_client_t *client, void *user_data);
 	void (*dtor)(void **ctx_ptr);
 	ZEND_RESULT_CODE (*once)(void *ctx);
 	ZEND_RESULT_CODE (*wait)(void *ctx, struct timeval *custom_timeout);

--- a/src/php_http_client_curl_event.c
+++ b/src/php_http_client_curl_event.c
@@ -242,7 +242,7 @@ static ZEND_RESULT_CODE php_http_client_curl_event_exec(void *context)
 	return SUCCESS;
 }
 
-static void *php_http_client_curl_event_init(php_http_client_t *client)
+static void *php_http_client_curl_event_init(php_http_client_t *client, void *user_data)
 {
 	php_http_client_curl_t *curl = client->ctx;
 	php_http_client_curl_event_context_t *ctx;


### PR DESCRIPTION
Using GCC 15

```
/builddir/build/BUILD/php-pecl-http-4.2.6-build/php-pecl-http-4.2.6/pecl_http-4.2.6/src/php_http_client_curl_event.c:299:9: error: initialization of 'void * (*)(void)' from incompatible pointer type 'void * (*)(php_http_client_t *)' {aka 'void * (*)(struct php_http_client *)'} [-Wincompatible-pointer-types]
  299 |         &php_http_client_curl_event_init,
      |         ^
/builddir/build/BUILD/php-pecl-http-4.2.6-build/php-pecl-http-4.2.6/pecl_http-4.2.6/src/php_http_client_curl_event.c:299:9: note: (near initialization for 'php_http_client_curl_event_ops.init')
/builddir/build/BUILD/php-pecl-http-4.2.6-build/php-pecl-http-4.2.6/pecl_http-4.2.6/src/php_http_client_curl_event.c:245:14: note: 'php_http_client_curl_event_init' declared here
  245 | static void *php_http_client_curl_event_init(php_http_client_t *client)
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

Reported during Fedora 42 mass rebuild
See https://bugzilla.redhat.com/show_bug.cgi?id=2341063  (build.log attached)

Using this patch, see https://koji.fedoraproject.org/koji/taskinfo?taskID=128350584
