### PR TITLE
ignore deprecated (php 8.5)

### DIFF
--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -8,14 +8,14 @@ function _ext($ext) {
 }
 
 function utf8locale() {
-	$locale = setlocale(LC_CTYPE, null);
+	$locale = @setlocale(LC_CTYPE, null);
 	if (stristr($locale, "utf") && substr($locale, -1) === "8") {
 		return true;
 	}
 	if (stristr(setlocale(LC_CTYPE, "C.UTF-8"), "utf")) {
 		return true;
 	}
-	$locale = setlocale(LC_CTYPE, null);
+	$locale = @setlocale(LC_CTYPE, null);
 	if (stristr($locale, "utf") && substr($locale, -1) === "8") {
 		return true;
 	}


### PR DESCRIPTION
Using 8.5.0alpha1

```
=====================================================================
BORKED TEST SUMMARY
---------------------------------------------------------------------
Deprecated: setlocale(): Passing null to parameter #2 ($locales) of type string is deprecated in /dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/skipif.inc on line 11 [/dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/urlparser004.phpt]
Deprecated: setlocale(): Passing null to parameter #2 ($locales) of type string is deprecated in /dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/skipif.inc on line 11 [/dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/urlparser006.phpt]
Deprecated: setlocale(): Passing null to parameter #2 ($locales) of type string is deprecated in /dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/skipif.inc on line 11 [/dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/urlparser010.phpt]
Deprecated: setlocale(): Passing null to parameter #2 ($locales) of type string is deprecated in /dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/skipif.inc on line 11 [/dev/shm/BUILD/php85-php-pecl-http-4.2.6-build/php85-php-pecl-http-4.2.6/pecl_http-4.2.6/tests/urlparser012.phpt]
=====================================================================
```

BTW, I think this deprecation was a mistake, will propose a revert.