### PR TITLE
return string in output handler

### DIFF
--- a/src/php_http_env_response.c
+++ b/src/php_http_env_response.c
@@ -1165,7 +1165,7 @@ static PHP_METHOD(HttpEnvResponse, __invoke)
 		} else {
 			php_http_message_body_append(obj->message->body, ob_str, ob_len);
 		}
-		RETURN_TRUE;
+		RETURN_EMPTY_STRING();
 	}
 }
 


### PR DESCRIPTION
Returning a non-string result from user output handler is deprecated

From https://wiki.php.net/rfc/deprecations_php_8_4

	A return value of true is treated like a context reset,
	which is identical to returning an empty string.